### PR TITLE
增加单步刷新API

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -65,7 +65,7 @@ Layout.loadImgs([
     'sub/Buffet_icon_GiftPlate.png',
     'sub/UI_Icon_Rating.png',
 ]).then(() => {
-  console.log('所有资源加载完成')；
+  console.log('所有资源加载完成');
 })
 ```
 
@@ -184,6 +184,9 @@ Layout.ticker.add(selfTickerFunc);
 
 ### Layout.ticker.stop()
 结束 Layout 的循环。
+
+### Layout.ticker.frame(step:number)
+执行指定次数帧后结束 Layout 的循环
 
 ### Layout.ticker.next(callback: Function)
 在 Layout 的下一次循环之后执行一次事件回调。

--- a/src/common/ticker.ts
+++ b/src/common/ticker.ts
@@ -12,6 +12,8 @@ export default class Ticker {
 
   private lastTime!: number;
 
+  private residueStep!:number; //剩余的执行步数，== 0 时候停止循环，小于0 不限制
+
   private update = () => {
     const time = Date.now();
     const deltaTime = time - this.lastTime;
@@ -38,7 +40,14 @@ export default class Ticker {
     }
 
     this.count += 1;
-    this.animationId = requestAnimationFrame(this.update);
+    this.residueStep --;
+    if(this.residueStep !== 0){
+      this.animationId = requestAnimationFrame(this.update);
+    }else{
+      this.animationId = null;
+      this.started = false;
+    }
+
   }
 
   cancelIfNeed() {
@@ -84,22 +93,32 @@ export default class Ticker {
   }
 
   start() {
-    if (!this.started) {
-      this.started = true;
-
-      this.lastTime = Date.now();
-
-      if (this.animationId === null && (this.cbs.length || this.innerCbs.length)) {
-        this.animationId = requestAnimationFrame(this.update);
-      }
-    }
+    this.frame(-1);
   }
 
   stop() {
     if (this.started) {
       this.started = false;
-
       this.cancelIfNeed();
     }
   }
+
+  /**
+   * 单步执行, 指定需要执行的帧数，用户改变数据后刷新使用，不需要一致执行循环
+   *
+   * @param step 0 不执行，负数，无限执行 正数执行指定桢后停止
+   */
+  frame(step:number){
+    if(this.started || step === 0){
+      return;
+    }
+    this.started = true;
+    this.lastTime = Date.now();
+    this.residueStep = step;
+    if (this.animationId === null && (this.cbs.length || this.innerCbs.length)) {
+      this.animationId = requestAnimationFrame(this.update);
+    }
+  }
+
+
 }


### PR DESCRIPTION
一般情况下，只有在数据刷新的时候才需要刷新UI，等刷新完成后主动关闭Ticker节省CPU性能，这次提交用户可以在更新数据后主动调用frame(xx)指定特定帧后停止